### PR TITLE
Fix session state error in chat filter

### DIFF
--- a/app.py
+++ b/app.py
@@ -198,7 +198,7 @@ def main() -> None:
             st.session_state.filter_tags = []
 
         with st.expander("検索オプション"):
-            st.session_state.filter_author = st.text_input("作成者で絞り込み", key="filter_author")
+            st.text_input("作成者で絞り込み", key="filter_author")
             tag_str = st.text_input("タグで絞り込み(カンマ区切り)", key="filter_tag")
             st.session_state.filter_tags = [t.strip() for t in tag_str.split(",") if t.strip()]
 


### PR DESCRIPTION
## Summary
- fix session state update for chat filter options

## Testing
- `python -m py_compile app.py src/*.py src/parsers/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688ab8a22a1c833391993bd8e4e8608c