### PR TITLE
Replace prints with logger calls

### DIFF
--- a/src/rag_engine.py
+++ b/src/rag_engine.py
@@ -6,8 +6,13 @@ from datetime import date
 from typing import List, Dict
 
 import openai
+import logging
 
 from .vector_store import VectorStoreManager
+
+logging.basicConfig(level=logging.INFO)
+
+logger = logging.getLogger(__name__)
 
 
 class RAGEngine:
@@ -37,14 +42,14 @@ class RAGEngine:
         if "expiration_date_start" not in search_filters and "expiration_date_end" not in search_filters:
             today = date.today().strftime("%Y-%m-%d")
             search_filters["expiration_date_gt"] = today
-            print(f"[DEBUG] 期限切れフィルタ適用: {today} より後の有効期限のみ検索")
+            logger.debug("期限切れフィルタ適用: %s より後の有効期限のみ検索", today)
 
         docs = self.vector_store.search(question, filters=search_filters)
 
         # **デバッグログを追加**
-        print(f"[DEBUG] 検索クエリ: {question}")
-        print(f"[DEBUG] 適用フィルタ: {search_filters}")
-        print(f"[DEBUG] 検索結果数: {len(docs)}")
+        logger.debug("検索クエリ: %s", question)
+        logger.debug("適用フィルタ: %s", search_filters)
+        logger.debug("検索結果数: %s", len(docs))
 
         if not docs:
             return {"answer": "ナレッジベースに情報がありません。登録済みナレッジの有効期限を確認してください。", "sources": []}
@@ -63,7 +68,7 @@ class RAGEngine:
             )
             answer = response.choices[0].message.content.strip()
         except openai.OpenAIError as e:
-            print(f"[DEBUG] OpenAI API エラー: {e}")
+            logger.error("OpenAI API エラー: %s", e)
             answer = "回答生成中にエラーが発生しました"
 
         sources = [doc.get("metadata", {}) for doc in docs]

--- a/src/vector_store.py
+++ b/src/vector_store.py
@@ -10,6 +10,8 @@ from typing import List, Dict, Any, Optional, Tuple
 import hashlib
 import logging
 
+logging.basicConfig(level=logging.INFO)
+
 import faiss
 import numpy as np
 import openai
@@ -91,55 +93,55 @@ class VectorStoreManager:
         text = chunk.get("text", "")
 
         # **デバッグログを追加**
-        print(f"[DEBUG] チャンクのメタデータ: {meta}")
-        print(f"[DEBUG] 適用中のフィルタ: {filters}")
+        logger.debug("チャンクのメタデータ: %s", meta)
+        logger.debug("適用中のフィルタ: %s", filters)
 
         for key, value in filters.items():
             if key == "expiration_date_gt":
                 exp = meta.get("expiration_date")
-                print(f"[DEBUG] 有効期限チェック: {exp} > {value}")
+                logger.debug("有効期限チェック: %s > %s", exp, value)
                 if not exp:
                     # 有効期限が設定されていない場合は除外
-                    print(f"[DEBUG] 有効期限未設定のため除外")
+                    logger.debug("有効期限未設定のため除外")
                     return False
                 # 文字列での日付比較（YYYY-MM-DD形式を前提）
                 if exp <= value:
-                    print(f"[DEBUG] 期限切れのため除外: {exp} <= {value}")
+                    logger.debug("期限切れのため除外: %s <= %s", exp, value)
                     return False
             elif key == "expiration_date_start":
                 exp = meta.get("expiration_date")
-                print(f"[DEBUG] 開始日チェック: {exp} >= {value}")
+                logger.debug("開始日チェック: %s >= %s", exp, value)
                 if exp and exp < value:
                     return False
             elif key == "expiration_date_end":
                 exp = meta.get("expiration_date")
-                print(f"[DEBUG] 終了日チェック: {exp} <= {value}")
+                logger.debug("終了日チェック: %s <= %s", exp, value)
                 if exp and exp > value:
                     return False
             elif key == "author":
                 if meta.get("author") != value:
-                    print(f"[DEBUG] 作成者不一致: {meta.get('author')} != {value}")
+                    logger.debug("作成者不一致: %s != %s", meta.get('author'), value)
                     return False
             elif key == "tag":
                 tags = meta.get("ai_tags", [])
                 if isinstance(value, str):
                     if value not in tags:
-                        print(f"[DEBUG] タグ不一致: {value} not in {tags}")
+                        logger.debug("タグ不一致: %s not in %s", value, tags)
                         return False
                 else:
                     if not any(v in tags for v in value):
-                        print(f"[DEBUG] タグ不一致: {value} not in {tags}")
+                        logger.debug("タグ不一致: %s not in %s", value, tags)
                         return False
             elif key == "keyword":
                 if value.lower() not in text.lower():
-                    print(f"[DEBUG] キーワード不一致: {value} not in text")
+                    logger.debug("キーワード不一致: %s not in text", value)
                     return False
             else:
                 if meta.get(key) != value:
-                    print(f"[DEBUG] メタデータ不一致: {meta.get(key)} != {value}")
+                    logger.debug("メタデータ不一致: %s != %s", meta.get(key), value)
                     return False
 
-        print(f"[DEBUG] フィルタ条件をすべて満たしています")
+        logger.debug("フィルタ条件をすべて満たしています")
         return True
 
     def add_document(self, original_path: Path, chunks: List[Dict], thumbnail_path: Optional[Path]) -> None:


### PR DESCRIPTION
## Summary
- swap print statements for logger calls in vector store and rag engine
- configure loggers so debug statements work as expected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c44d22a7c8333a2c53212cf8c8e30